### PR TITLE
Add more extensions

### DIFF
--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -145,6 +145,7 @@ jenkins:
       {{- end }}
       maxRequestsPerHostStr: {{ .Values.agent.maxRequestsPerHostStr | quote }}
       name: "kubernetes"
+      name: "{{ .Values.agent.kubernetesName }}"
       namespace: "{{ template "jenkins.agent.namespace" . }}"
       serverUrl: "https://kubernetes.default"
       {{- if .Values.agent.enabled }}

--- a/charts/jenkins/templates/jenkins-controller-svc.yaml
+++ b/charts/jenkins/templates/jenkins-controller-svc.yaml
@@ -1,3 +1,4 @@
+{{ $targetPort := .Values.controller.targetPort }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,14 +26,14 @@ spec:
   ports:
     - port: {{.Values.controller.servicePort}}
       name: http
-      targetPort: {{ .Values.controller.targetPort }}
+      targetPort: {{ $targetPort }}
       {{- if (and (eq .Values.controller.serviceType "NodePort") (not (empty .Values.controller.nodePort))) }}
       nodePort: {{.Values.controller.nodePort}}
       {{- end }}
 {{- range $index, $port := .Values.controller.extraPorts }}
     - port: {{ $port.port }}
       name: {{ $port.name }}
-      targetPort: {{ $port.port }}
+      targetPort: {{ $targetPort }}
 {{- end }}
   selector:
     "app.kubernetes.io/component": "{{ .Values.controller.componentName }}"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -497,6 +497,7 @@ agent:
   jenkinsUrl:
   # connect to the specified host and port, instead of connecting directly to the Jenkins controller
   jenkinsTunnel:
+  kubernetesName: "kubernetes"
   kubernetesConnectTimeout: 5
   kubernetesReadTimeout: 15
   maxRequestsPerHostStr: "32"


### PR DESCRIPTION
Extending some features to adapt from the company's own usage:

- Kubernetes plugin's cluster name can be customized
- the service target port should be as the same as Pod's no matter how many ports being set